### PR TITLE
Update frab URL in README

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -7,5 +7,5 @@ There is also an android app that makes use of the output of this script.
 You can find it on github [4].
 
 [1] http://www.pentabarf.org
-[2] https://github.com/oneiros/frab 
+[2] https://github.com/frab/frab 
 [3] https://github.com/Duckattack/FrOSConSchedule


### PR DESCRIPTION
I think frab/frab is the main repository now.
